### PR TITLE
Make it easy to launch into an existing VPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,31 @@ basis with an options key:
                                                          "EC2KeyName" "mykey"
                                                          "ImageId" "ami-cbab67a2"}}}]}}
 
+### Deploying within a VPC
+
+It is frequently necessary to deploy ElaticBeanstalk applications within a VPC.
+This can be accomplished by setting a number of option settings that specify the VpcId,
+security group, etc. However, the physical resource IDs are needed. For convenience,
+the `:stack` key allows a stack and associated option settings to be configured by
+logical resource ID. The logical IDs of the resources within the named stack are
+converted to physical resource IDs automatically.
+
+    :aws
+    {:beanstalk
+     {:environments
+      [{:name "dev"
+        :stack {:name "my-application-stack"
+                :options {"aws:autoscaling:launchconfiguration"
+                          {"IamInstanceProfile" "RootInstanceProfile"
+                           "SecurityGroups" "BeanstalkSecurityGroup"}
+                          "aws:ec2:vpc"
+                          {"VpcId" "VPC"
+                          "Subnets" "PrivateSubnet"}}}
+        :options {"aws:autoscaling:asg" {"MinSize" "1" "MaxSize" "1"}
+                  "aws:autoscaling:launchconfiguration" {"InstanceType" "m1.medium"
+                                                         "EC2KeyName" "mykey"
+                                                         "ImageId" "ami-cbab67a2"}}}]}}
+
 ### S3 Buckets
 
 [Amazon Elastic Beanstalk][1] uses


### PR DESCRIPTION
It is somewhat of a pain to launch an app into a VPC, as you need to know the physical resource IDs to reference, and as far as I can tell the tools don't offer support for this through .ebextensions in any convenient way (e.g., via a Ref). It's not a big deal if you have a stable stack, but I find that I destroy / recreate mine during development a lot and it becomes a pain to lookup all of the physical IDs and re-enter everything into the option settings config file.

I'll be attaching a pull request for a small change that I made that makes this much easier. Basically, it creates a class of options in the project.clj file under the :stack key. All of the options specified in the hash under this key are then looked up, from the given stack, by logical ID, and inserted into the create environment request with the appropriate keys / physical ID values. There is an example in the README.

If this seems useful, but you'd like something changed, let me know and I'm glad to rework it.

Thanks!
