### PR TITLE
Add deploy-version subtask

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ to the deploy command.
 
     $ lein beanstalk deploy development target/myproject.war
 
+#### Rolling Version Deploy
+
+A normal deployment will incur some downtime, as both the environment
+settings update and the version deployment will stop the Tomcat server
+on all EC2 instances at once. There are several work-arounds for this
+(see [Deploying Versions with Zero Downtime][7],
+[Demystified – Zero Downtime with AWS Elastic Beanstalk][8], and my
+preferred Blue-Green approach from [ThoughtWorks][9]), but all of them
+have drawbacks compared to Elastic Beanstalk's new (as of October 2014)
+[Rolling Version Deploy feature][10].
+
+If you are only deploying a new version and **not** changing any
+environment settings (i.e. Software Configuration > Environment Properties
+in the AWS Elastic Beanstalk console for your environment), you can
+use the `deploy-version` command:
+
+    $ lein beanstalk deploy-version development
+
+You can also specify a custom WAR as above.
+
+`deploy-version` will verify that you have no differences between the
+Elastic Beanstalk environment's settings and the environment's `:env`
+map in `:aws :beanstalk :environments` in your `project.clj`. If there
+are any differences, the deployment will abort through an exception
+and you will need to proceed with a normal deployment in order to update
+the environment settings automatically.
+
 ### Info
 
 To get information about the application itself run
@@ -341,3 +368,7 @@ We also welcome your contributions and will do our best to keep this repo update
 [4]: http://docs.aws.amazon.com/elasticbeanstalk/latest/APIReference/API_ListAvailableSolutionStacks.html
 [5]: http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/command-options.html
 [6]: http://aws.typepad.com/aws/2013/12/background-task-handling-for-aws-elastic-beanstalk.html
+[7]: http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.CNAMESwap.html
+[8]: http://www.hudku.com/blog/demystified-zero-downtime-with-amazon/
+[9]: http://www.thoughtworks.com/insights/blog/implementing-blue-green-deployments-aws
+[10]: http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rolling-version-deploy.html

--- a/src/leiningen/beanstalk.clj
+++ b/src/leiningen/beanstalk.clj
@@ -45,6 +45,14 @@
          (aws/deploy-environment project env))
        (println (str "Environment '" env-name "' not defined!")))))
 
+(defn deploy-version
+  "Deploy a new version of the current project to Amazon Elastic Beanstalk."
+  ([project]
+     (println "Usage: lein beanstalk deploy-version <environment>"))
+  ([project env-name & [war-file]]
+     (binding [aws/*update-environment-settings?* false]
+       (deploy project env-name war-file))))
+
 (defn terminate
   "Terminte the environment for the current project on Amazon Elastic Beanstalk."
   ([project]
@@ -119,15 +127,16 @@
 
 (defn beanstalk
   "Manage Amazon's Elastic Beanstalk service."
-  {:help-arglists '([clean deploy info terminate])
-   :subtasks [#'clean #'deploy #'info #'terminate]}
+  {:help-arglists '([clean deploy deploy-version info terminate])
+   :subtasks [#'clean #'deploy #'deploy-version #'info #'terminate]}
   ([project]
      (println (help-for "beanstalk")))
   ([project subtask & args]
      (aws/quiet-logger)
      (case subtask
-       "clean"     (apply clean project args)
-       "deploy"    (apply deploy project args)
-       "info"      (apply info project args)
-       "terminate" (apply terminate project args)
+       "clean"          (apply clean project args)
+       "deploy"         (apply deploy project args)
+       "deploy-version" (apply deploy-version project args)
+       "info"           (apply info project args)
+       "terminate"      (apply terminate project args)
        (println (help-for "beanstalk")))))

--- a/src/leiningen/beanstalk.clj
+++ b/src/leiningen/beanstalk.clj
@@ -36,19 +36,11 @@
   "Deploy the current project to Amazon Elastic Beanstalk."
   ([project]
      (println "Usage: lein beanstalk deploy <environment>"))
-  ([project env-name]
+  ([project env-name & [war-file]]
      (if-let [env (get-project-env project env-name)]
-       (let [filename (war-filename project)
-             path (uberwar project filename)]
-         (aws/s3-upload-file project path)
-         (aws/create-app-version project filename)
-         (aws/deploy-environment project env))
-       (println (str "Environment '" env-name "' not defined!"))))
-  ([project env-name war-file]
-     (if-let [env (get-project-env project env-name)]
-       (let [filename (war-filename war-file)
-             path war-file]
-         (aws/s3-upload-file project path filename)
+       (let [filename (war-filename (or war-file project))
+             path (or war-file (uberwar project filename))]
+         (aws/s3-upload-file project path (when war-file filename))
          (aws/create-app-version project filename)
          (aws/deploy-environment project env))
        (println (str "Environment '" env-name "' not defined!")))))

--- a/src/leiningen/beanstalk.clj
+++ b/src/leiningen/beanstalk.clj
@@ -54,7 +54,7 @@
        (deploy project env-name war-file))))
 
 (defn terminate
-  "Terminte the environment for the current project on Amazon Elastic Beanstalk."
+  "Terminate the environment for the current project on Amazon Elastic Beanstalk."
   ([project]
      (println "Usage: lein beanstalk terminate <environment>"))
   ([project env-name]

--- a/src/leiningen/beanstalk/aws.clj
+++ b/src/leiningen/beanstalk/aws.clj
@@ -1,6 +1,7 @@
 (ns leiningen.beanstalk.aws
   "AWS-specific libraries."
   (:require
+    [clojure.data :as data]
     [clojure.java.io :as io]
     [clojure.string :as str])
   (:import
@@ -14,6 +15,7 @@
     com.amazonaws.services.elasticbeanstalk.model.CreateEnvironmentRequest
     com.amazonaws.services.elasticbeanstalk.model.DeleteApplicationRequest
     com.amazonaws.services.elasticbeanstalk.model.DeleteApplicationVersionRequest
+    com.amazonaws.services.elasticbeanstalk.model.DescribeConfigurationSettingsRequest
     com.amazonaws.services.elasticbeanstalk.model.DescribeEnvironmentsRequest
     com.amazonaws.services.elasticbeanstalk.model.UpdateEnvironmentRequest
     com.amazonaws.services.elasticbeanstalk.model.S3Location
@@ -156,10 +158,13 @@
     {"AWS_ACCESS_KEY_ID" access-key
      "AWS_SECRET_KEY" secret-key}))
 
+(defn merge-env-vars [project options]
+  (merge (default-env-vars project)
+         (-> project :aws :beanstalk :env)
+         (:env options)))
+
 (defn env-var-options [project options]
-  (for [[key value] (merge (default-env-vars project)
-                           (-> project :aws :beanstalk :env)
-                           (:env options))]
+  (for [[key value] (merge-env-vars project options)]
     (ConfigurationOptionSetting.
      "aws:elasticbeanstalk:application:environment"
      (if (keyword? key)
@@ -202,6 +207,29 @@
       (.setEnvironmentName (.getEnvironmentName env))
       (.setOptionSettings (env-var-options project options)))))
 
+(defn get-environment-settings [project env]
+  (->> (.describeConfigurationSettings
+        (beanstalk-client project)
+        (doto (DescribeConfigurationSettingsRequest.)
+          (.setApplicationName (app-name project))
+          (.setEnvironmentName (.getEnvironmentName env))))
+       (.getConfigurationSettings)
+       first
+       (.getOptionSettings)
+       (filter #(= "aws:elasticbeanstalk:application:environment" (.getNamespace %)))
+       (map #(vector (.getOptionName %) (.getValue %)))
+       (into {})))
+
+(defn assert-environment-settings-unchanged [project env options]
+  (let [[local remote _] (data/diff (merge-env-vars project options)
+                                    (get-environment-settings project env))]
+    (when-not (or (and (empty? local) (empty? remote))
+                  (every? #{"JDBC_CONNECTION_STRING" "PARAM1" "PARAM2" "PARAM3" "PARAM4" "PARAM5"}
+                          (keys remote)))
+      (throw (IllegalStateException.
+              (format "Cannot deploy version because environment settings have changed; local %s; remote %s"
+                      local remote))))))
+
 (defn update-environment-version [project env]
   (.updateEnvironment
     (beanstalk-client project)
@@ -243,11 +271,16 @@
        (let [value (poll)]
          (if (pred value) value (recur))))))
 
+(def ^:dynamic *update-environment-settings?* true)
+
 (defn update-environment [project env {name :name :as options}]
   (println (str "Updating '" name "' environment")
            "(this may take several minutes)")
-  (update-environment-settings project env options)
-  (poll-until ready? #(get-env project name))
+  (if *update-environment-settings?*
+    (do
+      (update-environment-settings project env options)
+      (poll-until ready? #(get-env project name)))
+    (assert-environment-settings-unchanged project env options))
   (update-environment-version project env))
 
 (defn deploy-environment

--- a/src/leiningen/beanstalk/aws.clj
+++ b/src/leiningen/beanstalk/aws.clj
@@ -102,24 +102,16 @@
     (.createBucket client bucket region)))
 
 (defn s3-upload-file
-  ([project filepath]
-    (let [bucket  (s3-bucket-name project)
-          file    (io/file filepath)
-          ep-desc (project-endpoint project s3-endpoints)]
-      (doto (AmazonS3Client. (credentials project))
-        (.setEndpoint (:ep ep-desc))
-        (create-bucket bucket (:region ep-desc))
-        (.putObject bucket (.getName file) file))
-      (println "Uploaded" (.getName file) "to S3 Bucket")))
-  ([project filepath filename]
-    (let [bucket  (s3-bucket-name project)
-          file    (io/file filepath)
-          ep-desc (project-endpoint project s3-endpoints)]
+  [project filepath & [filename]]
+  (let [bucket   (s3-bucket-name project)
+        file     (io/file filepath)
+        filename (or filename (.getName file))
+        ep-desc  (project-endpoint project s3-endpoints)]
       (doto (AmazonS3Client. (credentials project))
         (.setEndpoint (:ep ep-desc))
         (create-bucket bucket (:region ep-desc))
         (.putObject bucket filename file))
-      (println "Uploaded" filename "to S3 Bucket"))))
+      (println "Uploaded" filename "to S3 Bucket")))
 
 (defn- beanstalk-client [project]
   (doto (AWSElasticBeanstalkClient. (credentials project))


### PR DESCRIPTION
From the section I added to the README.md:
#### Rolling Version Deploy

A normal deployment will incur some downtime, as both the environment
settings update and the version deployment will stop the Tomcat server
on all EC2 instances at once. There are several work-arounds for this
(see [Deploying Versions with Zero Downtime](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.CNAMESwap.html),
[Demystified – Zero Downtime with AWS Elastic Beanstalk](http://www.hudku.com/blog/demystified-zero-downtime-with-amazon/), and my
preferred Blue-Green approach from [ThoughtWorks](http://www.thoughtworks.com/insights/blog/implementing-blue-green-deployments-aws)), but all of them
have drawbacks compared to Elastic Beanstalk's new (as of October 2014)
[Rolling Version Deploy feature](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.rolling-version-deploy.html).

If you are only deploying a new version and **not** changing any
environment settings (i.e. Software Configuration > Environment Properties
in the AWS Elastic Beanstalk console for your environment), you can
use the `deploy-version` command:

```
$ lein beanstalk deploy-version development
```

You can also specify a custom WAR as above.

`deploy-version` will verify that you have no differences between the
Elastic Beanstalk environment's settings and the environment's `:env`
map in `:aws :beanstalk :environments` in your `project.clj`. If there
are any differences, the deployment will abort through an exception
and you will need to proceed with a normal deployment in order to update
the environment settings automatically.
